### PR TITLE
feat: Add Cloud Build Trigger for the Terraform repository itself

### DIFF
--- a/cloudbuild/terraform-repo.tf
+++ b/cloudbuild/terraform-repo.tf
@@ -1,0 +1,18 @@
+resource "google_cloudbuild_trigger" "terraform_repo_trigger" {
+    name = "terraform-gcp-config-trigger"
+    description = "Auto-trigger Terraform apply when code is merged to master"
+
+    location = var.region_id
+
+    github {
+        name = "Terraform-GCP-config"
+        owner = "nvd11"
+        push {
+            branch = "master"
+            invert_regex = false # means trigger on the specified branch
+        }
+    }
+
+    filename = "cloudbuild.yaml"
+    service_account = data.google_service_account.cloudbuild_sa.id
+}


### PR DESCRIPTION
This PR adds the GitOps trigger to listen to master branch pushes and execute cloudbuild.yaml. This resolves the chicken-and-egg problem by self-hosting the IaC pipeline.