### PR TITLE
fix: correct Eventarc methodName and add run.invoker role

### DIFF
--- a/autorestart_function/main.tf
+++ b/autorestart_function/main.tf
@@ -40,6 +40,14 @@ resource "google_project_iam_member" "event_receiver" {
   member  = "serviceAccount:${google_service_account.autorestart_sa.email}"
 }
 
+# Grant the Service Account the 'Cloud Run Invoker' role.
+# Eventarc requires this permission to invoke the Gen 2 Cloud Function (which runs on Cloud Run).
+resource "google_project_iam_member" "run_invoker" {
+  project = var.project_id
+  role    = "roles/run.invoker"
+  member  = "serviceAccount:${google_service_account.autorestart_sa.email}"
+}
+
 
 # ==============================================================================
 # Cloud Storage & Source Code Packaging
@@ -149,7 +157,7 @@ resource "google_cloudfunctions2_function" "autorestart_fn" {
     # This ensures the function isn't needlessly triggered by other random Compute Engine logs.
     event_filters {
       attribute = "methodName"
-      value     = "v1.compute.instances.preempted"
+      value     = "compute.instances.preempted"
     }
   }
 }


### PR DESCRIPTION
Fixes the issue where the preempted VM event was not triggered due to incorrect `methodName` in the Eventarc trigger filter. Also adds the missing `roles/run.invoker` role which is required for Eventarc to successfully invoke the underlying Cloud Run service of the Gen 2 Cloud Function.