### PR TITLE
fix: grant Pub/Sub Service Agent the Token Creator role for Eventarc

### DIFF
--- a/autorestart_function/main.tf
+++ b/autorestart_function/main.tf
@@ -49,6 +49,21 @@ resource "google_project_iam_member" "run_invoker" {
 }
 
 
+# Get the Google project data to access the project number dynamically
+data "google_project" "project" {
+  project_id = var.project_id
+}
+
+# Grant the GCP Pub/Sub Service Agent the required Token Creator role.
+# Eventarc relies on Pub/Sub to push events to Cloud Run (Cloud Functions Gen 2).
+# The Pub/Sub agent needs this role to create OIDC tokens acting as the trigger Service Account.
+resource "google_project_iam_member" "pubsub_token_creator" {
+  project = var.project_id
+  role    = "roles/iam.serviceAccountTokenCreator"
+  member  = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-pubsub.iam.gserviceaccount.com"
+}
+
+
 # ==============================================================================
 # Cloud Storage & Source Code Packaging
 # ==============================================================================


### PR DESCRIPTION
This PR fixes the `401 Unauthorized` issue caused by the missing OIDC token during Eventarc invocation. It dynamically grants the `roles/iam.serviceAccountTokenCreator` role to the GCP official Pub/Sub Service Agent, allowing it to impersonate the trigger Service Account when pushing events to the Gen 2 Cloud Function (Cloud Run).