### PR TITLE
fix: increase Cloud Function memory to 1G

### DIFF
--- a/autorestart_function/main.tf
+++ b/autorestart_function/main.tf
@@ -144,7 +144,7 @@ resource "google_cloudfunctions2_function" "autorestart_fn" {
   # Configure the runtime environment execution parameters for the function.
   service_config {
     max_instance_count    = 1      # Cap scaling to 1 to prevent runaway costs/concurrent executions
-    available_memory      = "256M" # Allocate just enough memory for simple API calls
+    available_memory      = "1G" # Allocate enough memory to prevent OOM errors from the Google Cloud SDK
     timeout_seconds       = 60     # Abort the execution if it hangs for more than 60 seconds
     
     # Attach our tightly scoped, custom Service Account to this function's execution environment.


### PR DESCRIPTION
This PR increases the memory limit of the `autorestart-spot-vm` Cloud Function from 256MB to 1G. The `google-cloud-compute` Python SDK requires more memory than the default 256MB, which caused `Memory limit of 244 MiB exceeded with 249 MiB used` (OOM) errors during container startup.