### PR TITLE
fix: correct eventarc trigger region and add run.invoker IAM

### DIFF
--- a/autorestart_function/main.tf
+++ b/autorestart_function/main.tf
@@ -163,8 +163,8 @@ resource "google_cloudfunctions2_function" "autorestart_fn" {
 
   # This block automatically creates and binds an Eventarc trigger to the Cloud Function.
   event_trigger {
-    # Audit logs are global resources, so the trigger listening to them must also be global.
-    trigger_region        = "global"
+    # Compute Engine audit logs are regional (based on the VM's region), not global.
+    trigger_region        = var.region_id
     
     # We are explicitly listening for a newly written Cloud Audit Log entry.
     event_type            = "google.cloud.audit.log.v1.written"

--- a/autorestart_function/main.tf
+++ b/autorestart_function/main.tf
@@ -48,6 +48,16 @@ resource "google_project_iam_member" "run_invoker" {
   member  = "serviceAccount:${google_service_account.autorestart_sa.email}"
 }
 
+# Grant the Service Account the 'Cloud Run Invoker' role explicitly on the underlying Cloud Run service.
+# This solves the 401 Unauthorized issue where Eventarc fails to trigger the Gen 2 Cloud Function.
+resource "google_cloud_run_service_iam_member" "function_run_invoker" {
+  project  = var.project_id
+  location = var.region_id
+  service  = google_cloudfunctions2_function.autorestart_fn.name
+  role     = "roles/run.invoker"
+  member   = "serviceAccount:${google_service_account.autorestart_sa.email}"
+}
+
 
 # Get the Google project data to access the project number dynamically
 data "google_project" "project" {


### PR DESCRIPTION
This PR fixes two issues with the Eventarc trigger for the autorestart-spot-vm Cloud Function:

1. **IAM Permissions**: Explicitly binds `roles/run.invoker` to the underlying Cloud Run service to fix the 401 Unauthorized errors when Eventarc attempts to push events.
2. **Eventarc Region**: Changes the Eventarc trigger region from `global` to `var.region_id`. Compute Engine audit logs for VM preemptions are regional, so a global trigger cannot capture them.