### PR TITLE
Fix: Route preempted System Events via Pub/Sub for Eventarc

### DIFF
--- a/autorestart_function/main.tf
+++ b/autorestart_function/main.tf
@@ -75,6 +75,38 @@ resource "google_project_iam_member" "pubsub_token_creator" {
 
 
 # ==============================================================================
+# Pub/Sub Topic & Log Router Sink for Preemption (System Events)
+# ==============================================================================
+
+# Create a dedicated Pub/Sub topic to receive the intercepted preemption system events.
+resource "google_pubsub_topic" "preemption_topic" {
+  name    = "autorestart-preemption-topic"
+  project = var.project_id
+}
+
+# Create a Log Router Sink that strictly filters for the "compute.instances.preempted" system event
+# and forwards the matched log entries to the Pub/Sub topic created above.
+resource "google_logging_project_sink" "preemption_sink" {
+  name                   = "autorestart-preemption-sink"
+  project                = var.project_id
+  destination            = "pubsub.googleapis.com/projects/${var.project_id}/topics/${google_pubsub_topic.preemption_topic.name}"
+  
+  # Strictly filter for compute.instances.preempted (System Event)
+  filter                 = "protoPayload.methodName=\"compute.instances.preempted\""
+  unique_writer_identity = true
+}
+
+# Grant the Log Router Sink's automatically generated service account the publisher role
+# on the Pub/Sub topic so it has permission to push the logs into it.
+resource "google_pubsub_topic_iam_member" "sink_publisher" {
+  project = var.project_id
+  topic   = google_pubsub_topic.preemption_topic.name
+  role    = "roles/pubsub.publisher"
+  member  = google_logging_project_sink.preemption_sink.writer_identity
+}
+
+
+# ==============================================================================
 # Cloud Storage & Source Code Packaging
 # ==============================================================================
 
@@ -162,27 +194,12 @@ resource "google_cloudfunctions2_function" "autorestart_fn" {
   }
 
   # This block automatically creates and binds an Eventarc trigger to the Cloud Function.
+  # We use the Pub/Sub topic trigger since we route the system event via Log Router.
   event_trigger {
-    # Compute Engine audit logs are regional (based on the VM's region), not global.
     trigger_region        = var.region_id
-    
-    # We are explicitly listening for a newly written Cloud Audit Log entry.
-    event_type            = "google.cloud.audit.log.v1.written"
-    
-    # Identify the Service Account that Eventarc will use to trigger the function.
+    event_type            = "google.cloud.pubsub.topic.v1.messagePublished"
+    pubsub_topic          = google_pubsub_topic.preemption_topic.id
     service_account_email = google_service_account.autorestart_sa.email
-    
-    # Filter #1: We only care about events originating from the Compute Engine API.
-    event_filters {
-      attribute = "serviceName"
-      value     = "compute.googleapis.com"
-    }
-    
-    # Filter #2: We strictly filter for the exact API method invoked when a Spot VM is preempted.
-    # This ensures the function isn't needlessly triggered by other random Compute Engine logs.
-    event_filters {
-      attribute = "methodName"
-      value     = "compute.instances.preempted"
-    }
+    retry_policy          = "RETRY_POLICY_DO_NOT_RETRY"
   }
 }

--- a/autorestart_function/src/main.py
+++ b/autorestart_function/src/main.py
@@ -1,6 +1,8 @@
 # Import the functions_framework library, which is the official framework provided by Google Cloud
 # for writing event-driven Cloud Functions (v2). It handles the HTTP requests sent by Eventarc
 # and translates them into Python CloudEvent objects.
+import base64
+import json
 import functions_framework
 
 # Import the Google Cloud Compute Engine (GCE) API client library.
@@ -15,7 +17,7 @@ from google.cloud import compute_v1
 def restart_vm(cloud_event):
     """
     This is the core handler function. It gets triggered whenever Eventarc detects a matching 
-    Compute Engine audit log (such as a preemption event).
+    message on the Pub/Sub topic (from the Log Router Sink for preemption events).
     
     Args:
         cloud_event: An object containing all the metadata and the payload of the event.
@@ -23,7 +25,15 @@ def restart_vm(cloud_event):
     
     # Extract the core 'data' dictionary from the CloudEvent object.
     # This 'data' payload actually contains the original raw JSON log entry from Cloud Audit Logs.
-    data = cloud_event.data
+    # Check if the event data contains a Pub/Sub message
+    if "message" in cloud_event.data and "data" in cloud_event.data["message"]:
+        # The 'data' field is a base64-encoded string representing the original JSON LogEntry
+        pubsub_message = cloud_event.data["message"]["data"]
+        # Decode base64 to string, then parse the JSON string into a Python dictionary
+        data = json.loads(base64.b64decode(pubsub_message).decode('utf-8'))
+    else:
+        # Fallback just in case we receive the raw data directly
+        data = cloud_event.data
     
     # In GCP Cloud Audit Logs, all the crucial operational details are nested inside 
     # the 'protoPayload' field. We use the safe .get() method to retrieve it, 


### PR DESCRIPTION
## Description
The previous implementation used Eventarc with the `google.cloud.audit.log.v1.written` event type to capture `compute.instances.preempted`. However, GCP officially categorizes preemption as a **System Event**, which Eventarc audit log triggers cannot capture.

## Changes
- Created a new Pub/Sub topic to receive the preemption events.
- Created a Log Router Sink filtering for `protoPayload.methodName="compute.instances.preempted"` and forwarding it to the Pub/Sub topic.
- Updated the Gen 2 Cloud Function's Eventarc trigger to use `google.cloud.pubsub.topic.v1.messagePublished`.
- Updated the Python code to gracefully decode the Pub/Sub `message.data` base64 payload into the original JSON LogEntry.
