### PR TITLE
fix(autorestart): add 15s delay to avoid VM start race condition during preemption

### DIFF
--- a/autorestart_function/src/main.py
+++ b/autorestart_function/src/main.py
@@ -23,6 +23,11 @@ def restart_vm(cloud_event):
         cloud_event: An object containing all the metadata and the payload of the event.
     """
     
+    import time
+    # Add a 15-second delay to avoid race condition with VM termination state
+    print("Sleeping for 15 seconds to allow the VM to fully transition to TERMINATED state...")
+    time.sleep(15)
+
     # Extract the core 'data' dictionary from the CloudEvent object.
     # This 'data' payload actually contains the original raw JSON log entry from Cloud Audit Logs.
     # Check if the event data contains a Pub/Sub message


### PR DESCRIPTION
When a Spot VM is preempted, GCP sends a `compute.instances.preempted` log almost instantly. Our Eventarc-triggered Cloud Function fires too fast and attempts a `compute.instances.start` while the VM is still actively in the STOPPING transition, causing a `RESOURCE_NOT_READY_WITH_DETAILS` fingerprint mismatch error.

This PR adds a 15-second `time.sleep()` to allow the VM to fully reach the `TERMINATED` state before we attempt to boot it back up.